### PR TITLE
Fix: Include localizable strings in deb package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,10 @@ ifeq ($(SIDELOADED),1)
 endif
 
 include $(THEOS_MAKE_PATH)/tweak.mk
+
+# Copy preference bundle resources to staging directory
+after-stage::
+	$(ECHO_NOTHING)mkdir -p $(THEOS_STAGING_DIR)/Library/PreferenceBundles/RedditFilter.bundle/en.lproj$(ECHO_END)
+	$(ECHO_NOTHING)if [ -d "layout/Library/Application Support/RedditFilter.bundle" ]; then \
+		cp -r "layout/Library/Application Support/RedditFilter.bundle"/* "$(THEOS_STAGING_DIR)/Library/PreferenceBundles/RedditFilter.bundle/"; \
+	fi$(ECHO_END)


### PR DESCRIPTION
Fixes the issue where preference bundle settings appear blank after installing the deb.

Changes:
- Added `after-stage` hook to copy preference bundle resources
- Ensures Root.strings file is included in the package
- Copies bundle from layout directory to /Library/PreferenceBundles/

This resolves the missing localizable strings issue when building with Theos.